### PR TITLE
diamond support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ h1 {
 
 ## Installation
 
-You can install Typi in three ways:
+You can install Typi in four ways:
 
 1. Bower: `bower install typi --save`
 2. npm: `npm install typi --save-dev`
+3. diamond: `diamond install typi`
 3. manual install (https://github.com/zellwk/typi/archive/master.zip)
 
 
@@ -79,6 +80,11 @@ Once you've downloaded Typi, include it in your project with:
 ```scss
 // Change `path-to-typi` with the correct path!
 @import 'path-to-typi/scss/typi';
+```
+
+If you are using diamond, it can be imported with:
+```scss
+@import '~typi';
 ```
 
 ## Configuration

--- a/diamond.json
+++ b/diamond.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "typi": "^3.1.0"
-  },
   "name": "typi",
   "version": "3.1.0",
   "description": "A sass mixin to make responsive typography easy",

--- a/diamond.json
+++ b/diamond.json
@@ -1,6 +1,0 @@
-{
-  "name": "typi",
-  "version": "3.1.0",
-  "description": "A sass mixin to make responsive typography easy",
-  "main": "scss/_typi.scss"
-}

--- a/diamond.json
+++ b/diamond.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "typi": "^3.1.0"
+  },
+  "name": "typi",
+  "version": "3.1.0",
+  "description": "A sass mixin to make responsive typography easy",
+  "main": "scss/_typi.scss"
+}


### PR DESCRIPTION
Following up on our conversation via email I have added diamond support. 

To publish the package when you are ready, run the following commands:
Install diamond:
`npm i -g diamondpkg` 

Register for an account:
`diamond login`

Publish the package (run in package dir)
`diamond publish`